### PR TITLE
update unicode stripping for 0.11-a

### DIFF
--- a/CSplat/Ttyrec.pm
+++ b/CSplat/Ttyrec.pm
@@ -535,6 +535,10 @@ sub tv_frame_strip {
   $rdat =~ s/\xe2\x88\xa9/\\/g;
   $rdat =~ s/\xe2\x8c\xa0/}/g;
   $rdat =~ s/\xe2\x89\x88/~/g;
+  $rdat =~ s/\xe2\x88\x86/{/g;
+  $rdat =~ s/\xc2\xa7/#/g;
+  $rdat =~ s/\xe2\x99\xa3/7/g;
+  $rdat =~ s/\xc2\xa9/^/g;
 
   $rdat
 }


### PR DESCRIPTION
This patch strips some more default Unicode characters introduced since 0.8 or so.  It fixes a fairly annoying problem in which the starting frame is computed wrong leading to display corruption until the screen is redrawn.

It would be good to clear the fetch daemon's cache because it stores those wrongly-computed starting frames, I believe.
