### PR TITLE
Replace "∙" with "." when stripping Unicode

### DIFF
--- a/CSplat/Ttyrec.pm
+++ b/CSplat/Ttyrec.pm
@@ -437,6 +437,7 @@ sub tv_frame_strip {
   $rdat =~ s/\xe2\x96\x92/#/g;
   $rdat =~ s/\xe2\x96\x91/*/g;
   $rdat =~ s/\xc2\xb7/./g;
+  $rdat =~ s/\xe2\x88\x99/./g;
   $rdat =~ s/\xe2\x97\xa6/,/g;
   $rdat =~ s/\xe2\x97\xbc/+/g;
   $rdat =~ s/\xe2\x88\xa9/\\/g;


### PR DESCRIPTION
The Unicode stripping doesn't handle bullet points as floor tiles, which look quite unappealing in many fonts:

![](http://i.imgur.com/Ir5sf.png)

This commit fixes that.

It would be nice to handle `■` for doors too, but that seems like it might have more false positives...
