### PR TITLE
Add CKO server to the sources

### DIFF
--- a/config/sources.yml
+++ b/config/sources.yml
@@ -213,3 +213,12 @@ sources:
       - https://crawl.jorgrun.rocks/morgue
     ttyrecs:
       - https://crawl.jorgrun.rocks/ttyrec
+
+  - name: cko
+    base: https://crawl.kelbi.org/crawl/meta
+    logs:
+      - '{0.21,0.22,git}/{milestones,logfile}{,-sprint,-zotdef}*'
+    morgues:
+      - https://crawl.kelbi.org/crawl/morgue
+    ttyrecs:
+      - https://crawl.kelbi.org/crawl/ttyrec


### PR DESCRIPTION
Now that CJR is going offline, we're adding this crawl server as an official one. Owned by floraline and hosted in NY, USA. Webtiles at https://crawl.kelbi.org:8081/#lobby with console access via ssh to crawl.kelbi.org with port 22 and username 'terminal' and using CAO key.