### PR TITLE
Don't strip ttyrec characters when sending to termcast

### DIFF
--- a/CSplat/Termcast.pm
+++ b/CSplat/Termcast.pm
@@ -270,7 +270,7 @@ sub play_ttyrec {
     if ($delay > 0) {
       select undef, undef, undef, $delay;
     }
-    $self->write(tv_frame_strip($fref->{data}));
+    $self->write($fref->{data});
     select undef, undef, undef, 1 if is_death_frame($fref->{data});
 
     if ($self->{_callbacks}) {


### PR DESCRIPTION
Not stripping the UNICODE/IBM/DEC characters would allow for viewers to see how the game really looked, and it would be useful for me in using the data in dcssreplay to get the correct output for tile view reproduction.

Tested by casting to termcast.org, watched in browser view, didn't see any issues due to including the stripped characters.